### PR TITLE
Use flocx-market instead of a mock backend (TG-196)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
-# Created by https://www.gitignore.io/api/node,linux,macos,python,django,windows
-# Edit at https://www.gitignore.io/?templates=node,linux,macos,python,django,windows
+# Created by https://www.gitignore.io/api/osx,node,linux,macos,python,django,windows,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=osx,node,linux,macos,python,django,windows,visualstudiocode
 
 ### Django ###
 *.log
@@ -266,6 +266,17 @@ typings/
 # DynamoDB Local files
 .dynamodb/
 
+### OSX ###
+# General
+
+# Icon must end with two \r
+
+# Thumbnails
+
+# Files that might appear in the root of a volume
+
+# Directories potentially created on remote AFP share
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 
@@ -321,6 +332,17 @@ typings/
 
 # Pyre type checker
 
+### VisualStudioCode ###
+.vscode/*
+# !.vscode/settings.json
+# !.vscode/tasks.json
+# !.vscode/launch.json
+# !.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
 ### Windows ###
 # Windows thumbnail cache files
 Thumbs.db
@@ -347,7 +369,7 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.gitignore.io/api/node,linux,macos,python,django,windows
+# End of https://www.gitignore.io/api/osx,node,linux,macos,python,django,windows,visualstudiocode
 
 ## Custom
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- VSCode files to `.gitignore`
+- `api/schema.py` to validate the schema in a request to create an offer
+- REST API endpoints to create an offer and get an offer's details
+
+### Removed
+
+- `handle_error` decorator from the flocx.py API service since it is already handled in the flocx_rest_api.py `@rest_utils.ajax` decorator
+
 ## [0.1.0] - 2019-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `api/schema.py` to validate the schema in a request to create an offer
 - REST API endpoints to create an offer and get an offer's details
 
+### Changed
+
+- The API to work with the flocx-market directly. This meant adding an `X-Auth-Token` header along with all API calls
+
 ### Removed
 
 - `handle_error` decorator from the flocx.py API service since it is already handled in the flocx_rest_api.py `@rest_utils.ajax` decorator
+- keystone service from `docker-compose.yml` since the flocx-ui plugin will now talk directly with the flocx-market API
 
 ## [0.1.0] - 2019-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2019-07-25
+
 ### Added
 
 - VSCode files to `.gitignore`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The API to work with the flocx-market directly. This meant adding an `X-Auth-Token` header along with all API calls
+- Developer documentation to reflect the API changes from a mock backend to using the flocx-market directly
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,14 @@ This project follows the Horizon plugin structure outlined in the [Horizon docs]
 ### Prerequisites
 
 * [docker](https://www.docker.com/) — as well as docker-compose
+* [flocx-keystone-dev](https://github.com/CCI-MOC/flocx-keystone-dev) - Flocx-keystone-dev should be running on port `5000`.
 * [flocx-market](https://github.com/CCI-MOC/flocx-market) — Flocx-market should be running on port `8080`.
 * [node.js](https://nodejs.org/) — The JavaScript tests and linters require both node and npm to be installed
 * [tox](https://tox.readthedocs.io) - Tox handles the python virtualenv.
 
 > You can also specify a host and a port for the flocx-market using the `FLOCX_API_HOST` and `FLOCX_API_PORT`.
 >
-> The defaults are `http://localhost` and `8080` respectively.
+> The defaults are `http://localhost` and `8081` respectively.
 
 ### Install dependencies
 
@@ -36,17 +37,21 @@ $ npm install
 
 ### Using docker
 
-Flocx-ui comes with a docker-compose file to automatically setup a keystone instance, configure a horizon dashboard at `http://localhost:8000`, and install the flocx-ui plugin on that instance:
+Make sure that the `flocx-keystone-dev`'s public url is set to `http://host.docker.internal:5000` using the following command before running the `docker-compose up` for keystone:
 
----
+```sh
+export KEYSTONE_PUBLIC_URL=http://host.docker.internal:5000
+```
 
 1. Startup the docker-compose setup
+
+Flocx-ui comes with a docker-compose file to automatically setup a horizon dashboard at `http://localhost:8000` and install the flocx-ui plugin:
 
 ```sh
 $ docker-compose up
 ```
 
-#### The server should now be running at: `http://localhost:8000`.
+#### The server should now be running at: `http://localhost:8000`
 
 2. Login using development credentials:
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ $ sudo service apache2 restart
 ### Python tests
 
 ```bash
-$ tox
+$ npm run test:py
 ```
 
 ### JavaScript tests
 
 ```bash
-$ npm test
+$ npm run test:js
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,9 @@
 version: '3'
 services:
-  keystone:
-    image: jdtzmn/keystone-docker
-    environment:
-      - HOSTNAME=keystone
-      - KEYSTONE_ADMIN_PASSWORD=secret
   horizon:
     build: .
     environment:
+      - KEYSTONE_HOST=host.docker.internal
       - FLOCX_API_HOST=http://host.docker.internal
       - TOX_TESTENV_PASSENV=KEYSTONE_HOST FLOCX_*
     volumes: 

--- a/flocx_ui/api/flocx.py
+++ b/flocx_ui/api/flocx.py
@@ -16,49 +16,81 @@ HOST = os.getenv('FLOCX_API_HOST', DEFAULT_API_HOST)
 PORT = os.getenv('FLOCX_API_PORT', DEFAULT_API_PORT)
 BASE_URL = HOST + ':' + PORT
 
-def get(path):
+def generic_request(method, path, **kwargs):
+    """An alias for requests.request with the BASE_URL.
+
+    :param path: A url path
+    :param **kwargs: The keyword arguments defined below as well
+        as any additional arguments to be passed to the
+        requests.request call
+    :return: A request for the given path
+
+    :Keyword Arguments:
+        * token:
+            A token to be put into the X-Auth-Token header of the request
+    """
+
+    auth_token = kwargs.pop('token', None)
+    if auth_token:
+        headers = kwargs.pop('headers', {})
+        headers['X-Auth-Token'] = auth_token
+        kwargs['headers'] = headers
+
+    return requests.request(method, urljoin(BASE_URL, path), **kwargs)
+
+def get(path, **kwargs):
     """An alias for requests.get with the BASE_URL
 
     :param path: A url path
-    :return: A request for a given path
+    :param **kwargs: The keyword arguments to be passedto the request function
+    :return: A request for the given path
     """
-    return requests.get(urljoin(BASE_URL, path))
+    return generic_request('GET', path, **kwargs)
 
-def post(path, json=None):
+def post(path, **kwargs):
     """An alias for requests.post with the BASE_URL
 
     :param path: A url path
-    :return: A request for a given path
+    :param **kwargs: The keyword arguments to be passedto the request function
+    :return: A request for the given path
     """
-    return requests.post(urljoin(BASE_URL, path), None, json)
+    return generic_request('POST', urljoin(BASE_URL, path), **kwargs)
 
-def offer_list():
+def offer_list(request):
     """Retrieve a list of offers
 
     :param request: HTTP request
     :return A list of offers
     """
 
-    r = get('/offer')
+    r = get('/offer', token=request.user.token.id)
     data = r.json()
     return data
 
-def offer_create(offer):
+def offer_create(request, offer):
     """Create an offer
 
     :param offer: The offer to be created
+    :param request: HTTP request
     :raises AjaxError: If the offer param is invalid
     :return: The offer that was created
     """
     if not schema.validate_offer(offer, return_boolean=True):
         raise AjaxError(400, 'Invalid or insufficient input parameters. Cannot create offer.')
-    r = post('/offer', offer)
+    r = post('/offer', json=offer, token=request.user.token.id)
     data = r.json()
     return data
 
-def offer_get(offer_id):
+def offer_get(request, offer_id):
+    """Get an offer
+
+    :param offer_id: The offer id used to get the offer details
+    :param request: HTTP request
+    :raises AjaxError: If the offer_id is invalid
+    :return: The offer associated with the offer_id
+    """
     if not schema.validate_uuid(offer_id, return_boolean=True):
         raise AjaxError(400, 'Invalid Offer id.')
-    r = get('/offer/%r')
+    r = get('/offer/%r', token=request.user.token.id)
     data = r.json()
     return data

--- a/flocx_ui/api/flocx_rest_api.py
+++ b/flocx_ui/api/flocx_rest_api.py
@@ -15,12 +15,12 @@ class Offers(generic.View):
     url_regex = r'flocx/offer/$'
 
     @rest_utils.ajax()
-    def get(self, *_):
+    def get(self, request):
         """Get the list of offers
         :param request: HTTP request
         :return: List of offers
         """
-        offers = flocx.offer_list()
+        offers = flocx.offer_list(request)
         return offers
 
     @rest_utils.ajax(data_required=True)
@@ -31,7 +31,7 @@ class Offers(generic.View):
         :return: The created offer
         """
         offer_data = request.body
-        offer = flocx.offer_create(offer_data)
+        offer = flocx.offer_create(request, offer_data)
         return offer
 
 class Offer(generic.View):
@@ -39,11 +39,11 @@ class Offer(generic.View):
     url_regex = r'flocx/offer/(?P<offer_id>{})$'.format(UUID_REGEX)
 
     @rest_utils.ajax()
-    def get(self, offer_id):
+    def get(self, request, offer_id):
         """Show details on a particular offer
 
         :param offer_id: Offer uuid
         :return: The offer details
         """
-        offer = flocx.offer_get(offer_id)
+        offer = flocx.offer_get(request, offer_id)
         return offer

--- a/flocx_ui/api/flocx_rest_api.py
+++ b/flocx_ui/api/flocx_rest_api.py
@@ -7,18 +7,43 @@ from openstack_dashboard.api.rest import urls
 from openstack_dashboard.api.rest import utils as rest_utils
 
 from flocx_ui.api import flocx
-
+from flocx_ui.api.schema import UUID_REGEX
 
 @urls.register
-class Offer(generic.View):
+class Offers(generic.View):
 
     url_regex = r'flocx/offer/$'
 
     @rest_utils.ajax()
     def get(self, *_):
-        """Get the list of offers.
-        :param request: HTTP request.
-        :return: List of offers.
+        """Get the list of offers
+        :param request: HTTP request
+        :return: List of offers
         """
         offers = flocx.offer_list()
         return offers
+
+    @rest_utils.ajax(data_required=True)
+    def post(self, request):
+        """Create an offer
+
+        :param request: The request passed from the ajax decorator
+        :return: The created offer
+        """
+        offer_data = request.body
+        offer = flocx.offer_create(offer_data)
+        return offer
+
+class Offer(generic.View):
+
+    url_regex = r'flocx/offer/(?P<offer_id>{})$'.format(UUID_REGEX)
+
+    @rest_utils.ajax()
+    def get(self, offer_id):
+        """Show details on a particular offer
+
+        :param offer_id: Offer uuid
+        :return: The offer details
+        """
+        offer = flocx.offer_get(offer_id)
+        return offer

--- a/flocx_ui/api/schema.py
+++ b/flocx_ui/api/schema.py
@@ -1,0 +1,127 @@
+from datetime import datetime
+
+from schema import (Regex,
+                    Schema,
+                    And,
+                    Or,
+                    Use,
+                    SchemaError)
+
+UUID_REGEX = r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+def return_boolean_decorator(func):
+    """Decorator to intercept the **return_boolean keyword argument
+        and return False if there is a SchemaError instead of raising
+        an exception
+
+    :param func: The function to be wrapped
+    :return: A higher order component that handles the try and except
+    """
+    def handle_boolean_keyword(*args, **kwargs):
+        """A higher order component to handle the return_boolean keyword argument
+
+        :param *args: Any args to pass to the decorated function
+        :param **kwargs: See below
+        :raises SchemaError: If `return_boolean` is False
+        :return: The return value of the decorated function if a SchemaError is not thrown
+            Otherwise it will return False if `return_boolean` is True
+
+        :Keyword Arguments:
+        * return_boolean:
+            Whether to raise SchemaError or return false if the offer is invalid
+        """
+        return_boolean = kwargs.pop('return_boolean', None)
+        try:
+            return func(*args, **kwargs)
+        except SchemaError as err:
+            if return_boolean:
+                return False
+            raise err
+    return handle_boolean_keyword
+
+@return_boolean_decorator
+def validate_uuid(uuid, **_kwargs):
+    """Determines if the uuid parameter is a valid uuid
+
+    :param uuid: The uuid to be validated
+    :param **kwargs: See below
+    :raises SchemaError: If the uuid is not valid
+    :return: True if valid. Raises a SchemaError otherwise
+
+    :Keyword Arguments:
+        * return_boolean:
+            Whether to raise SchemaError or return false if the offer is invalid
+    """
+
+    return Regex(UUID_REGEX).validate(uuid)
+
+@return_boolean_decorator
+def validate_date(date_string):
+    """Determines if the date_string parameter is a valid date
+        and that it is formatted correctly
+
+    :param date_string: The date to be validated
+    :param **kwargs: See below
+    :raises SchemaError: If the date is invalid or not formatted correctly
+    :return: True if the date is valid and formatted correctly.
+            Raises a SchemaError otherwise
+
+    :Keyword Arguments:
+        * return_boolean:
+            Whether to raise SchemaError or return false if the offer is invalid
+    """
+    try:
+        datetime.strptime(date_string, '(%Y-%m-%dT%H:%M:%S%z)')
+        return True
+    except ValueError:
+        raise SchemaError('{} is not a valid date'.format(date_string))
+
+@return_boolean_decorator
+def validate_offer_status(status):
+    """Determines if the status is one of the valid status options
+
+    :param status: The status to be validated
+    :param **kwargs: See below
+    :raises SchemaError: If the status is not one of the options
+    :return: True if the status is one of the options. Raises a SchemaError otherwise
+
+    :Keyword Arguments:
+        * return_boolean:
+            Whether to raise SchemaError or return false if the offer is invalid
+    """
+    status_enum = [
+        'available',
+        'matched',
+        'used',
+        'cancelled',
+        'expired'
+    ]
+
+    return Schema(And(Use(lambda s: [s]), status_enum)).validate(status)
+
+@return_boolean_decorator
+def validate_offer(offer, **_kwargs):
+    """Determines if an offer dictionary is valid
+
+    :param offer: The offer to be validated
+    :param **kwargs: See below
+    :raises SchemaError: If the offer schema is not valid
+    :return: True if the offer schema is valid. Raises a SchemaError otherwise
+
+    :Keyword Arguments:
+        * return_boolean:
+            Whether to raise SchemaError or return false if the offer is invalid
+    """
+    return Schema({
+        'marketplace_offer_id': validate_uuid,
+        'provider_offer_id': validate_uuid,
+        'provider_id': validate_uuid,
+        'project_id': validate_uuid,
+        'marketplace_date_created': validate_date,
+        'status': validate_offer_status,
+        'server_id': validate_uuid,
+        'start_time': validate_date,
+        'end_time': validate_date,
+        'server_config': object,
+        'cost': Or(int, float)
+    }).validate(offer)

--- a/flocx_ui/test/tests/helpers.py
+++ b/flocx_ui/test/tests/helpers.py
@@ -32,12 +32,14 @@ class MockResponse: # pylint: disable=too-few-public-methods
     Usage:
 
     response = MockResponse()
+    response.status_code = 200
     response.content = '["json_content"]'
 
     This class is based on the requests.Response class
     """
 
     def __init__(self):
+        self.status_code = None
         self.content = None
         self.encoding = 'application/json'
 
@@ -74,8 +76,15 @@ class RequestFactory:
         return request
 
     def get(self, *args, **kwargs):
-        """Handle constructing get requests
+        """Handle constructing GET requests
 
         :return: The GET request
         """
         return self.generic('GET', *args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        """Handle constructing POST requests
+
+        :return: The POST request
+        """
+        return self.generic('POST', *args, **kwargs)

--- a/flocx_ui/test/tests/helpers.py
+++ b/flocx_ui/test/tests/helpers.py
@@ -37,7 +37,6 @@ class MockResponse: # pylint: disable=too-few-public-methods
 
     This class is based on the requests.Response class
     """
-
     def __init__(self):
         self.status_code = None
         self.content = None

--- a/flocx_ui/test/tests/test_data.json
+++ b/flocx_ui/test/tests/test_data.json
@@ -1,5 +1,5 @@
 {
-  "offer_list_response": [
+  "offer_list": [
     {
       "marketplace_offer_id": "b711b1ca-a77e-4392-a9b5-dc84c4f469ac",
       "provider_offer_id": "90894712-3b21-4bf7-9899-b4234530ff8b",
@@ -31,5 +31,43 @@
       },
       "cost": 11
     }
-  ]
+  ],
+  "offer": {
+    "marketplace_offer_id": "b711b1ca-a77e-4392-a9b5-dc84c4f469ac",
+    "provider_offer_id": "90894712-3b21-4bf7-9899-b4234530ff8b",
+    "provider_id": "b9752cc0-9bed-4f1c-8917-12ade7a6fdbe",
+    "project_id": "12a59a51-b4d6-497d-9f75-f56c409305c8",
+    "marketplace_date_created": "(2016-07-16T19:20:30-04:00)",
+    "status": "available",
+    "server_id": "fb878e3e-9425-4285-babf-0e58a7b091b2",
+    "start_time": "(2016-07-16T19:20:30-04:00)",
+    "end_time": "(2016-08-16T19:20:30-04:00)",
+    "server_config": {
+      "properties": {
+        "memory_gb": 10240,
+        "cpu_arch": "x86_64",
+        "cpu_physical_count": 4,
+        "cpu_core_count": 16,
+        "cpu_ghz": 3,
+        "disks": [
+          {
+            "size_gb": 500,
+            "model": "YOYODYNE 1234"
+          },
+          {
+            "size_gb": 1024,
+            "model": "evo840 ssd"
+          }
+        ]
+      }
+    },
+    "cost": 11
+  },
+  "invalid_offer": {
+    "this_is_invalid": true
+  },
+  "invalid_offer_error": {
+    "status": "Error",
+    "message": "Invalid or insufficient input parameters. Cannot create offer."
+  }
 }

--- a/flocx_ui/test/tests/test_flocx_rest_api.py
+++ b/flocx_ui/test/tests/test_flocx_rest_api.py
@@ -1,7 +1,9 @@
+import json
 from unittest import mock
 
 from openstack_dashboard.test import helpers as test
 
+from flocx_ui.api.flocx_rest_api import Offers as OffersAPI
 from flocx_ui.api.flocx_rest_api import Offer as OfferAPI
 from flocx_ui.test.tests.helpers import get_test_data, RequestFactory
 
@@ -17,11 +19,38 @@ class RestApiTests(test.TestCase):
         Getting the /api/flocx/offer/ endpoint should return a
         list of offers from the flocx service method
         """
-        testData = get_test_data('offer_list_response')
+        testData = get_test_data('offer_list')
         mock_offer_list.return_value = testData
 
         rf = RequestFactory()
         request = rf.get('/api/flocx/offer/')
+
+        offersAPI = OffersAPI()
+        response = offersAPI.get(request)
+        self.assertEqual(response.json, testData)
+
+    @mock.patch('flocx_ui.api.flocx.offer_create')
+    def test_create_offer(self, mock_offer_create):
+        testData = get_test_data('offer')
+        mock_offer_create.return_value = testData
+
+        rf = RequestFactory()
+        request = rf.post('/api/flocx/offer/',
+                          data=json.dumps(testData),
+                          content_type='application/json')
+
+        offersAPI = OffersAPI()
+        response = offersAPI.post(request)
+        self.assertEqual(response.json, testData)
+
+    @mock.patch('flocx_ui.api.flocx.offer_get')
+    def test_get_offer(self, mock_offer_get):
+        testData = get_test_data('offer')
+        mock_offer_get.return_value = testData
+        offer_id = testData['marketplace_offer_id']
+
+        rf = RequestFactory()
+        request = rf.get('/api/flocx/offer/{}'.format(offer_id))
 
         offerAPI = OfferAPI()
         response = offerAPI.get(request)

--- a/flocx_ui/test/tests/test_flocx_rest_api.py
+++ b/flocx_ui/test/tests/test_flocx_rest_api.py
@@ -53,5 +53,5 @@ class RestApiTests(test.TestCase):
         request = rf.get('/api/flocx/offer/{}'.format(offer_id))
 
         offerAPI = OfferAPI()
-        response = offerAPI.get(request)
+        response = offerAPI.get(request, offer_id)
         self.assertEqual(response.json, testData)

--- a/flocx_ui/test/tests/test_flocx_service.py
+++ b/flocx_ui/test/tests/test_flocx_service.py
@@ -6,6 +6,9 @@ from openstack_dashboard.test import helpers as test
 from flocx_ui.api.flocx import * # pylint: disable=wildcard-import,unused-wildcard-import
 from flocx_ui.test.tests.helpers import get_test_data, MockResponse
 
+mock_request = test.TestCase.mock_rest_request()
+mock_request.user.token.id = 'auth_token'
+
 class RestApiTests(test.TestCase):
     @mock.patch('flocx_ui.api.flocx.get')
     def test_get_offers(self, mock_get):
@@ -17,7 +20,7 @@ class RestApiTests(test.TestCase):
 
         mock_get.return_value = mock_response
 
-        output = offer_list()
+        output = offer_list(mock_request)
         self.assertEqual(output, testData)
 
     @mock.patch('flocx_ui.api.flocx.post')
@@ -31,14 +34,14 @@ class RestApiTests(test.TestCase):
 
         mock_post.return_value = mock_response
 
-        output = offer_create(testData)
+        output = offer_create(mock_request, testData)
         self.assertEqual(output, testData)
 
     def test_create_invalid_offer(self):
         testOffer = get_test_data('invalid_offer')
 
         try:
-            offer_create(testOffer)
+            offer_create(mock_request, testOffer)
             self.fail() # Above code should fail
         except AjaxError as err:
             status_code, msg = err.http_status, str(err)
@@ -57,13 +60,13 @@ class RestApiTests(test.TestCase):
 
         mock_get.return_value = mock_response
 
-        output = offer_get(testId)
+        output = offer_get(mock_request, testId)
         self.assertEqual(output, testOffer)
 
     def test_get_offer_invalid_id(self):
         invalid_offer_id = 'invalid_offer'
         try:
-            offer_get(invalid_offer_id)
+            offer_get(mock_request, invalid_offer_id)
             self.fail() # Above code should fail
         except AjaxError as err:
             status_code, msg = err.http_status, str(err)

--- a/flocx_ui/test/tests/test_flocx_service.py
+++ b/flocx_ui/test/tests/test_flocx_service.py
@@ -9,7 +9,7 @@ from flocx_ui.test.tests.helpers import get_test_data, MockResponse
 class RestApiTests(test.TestCase):
     @mock.patch('flocx_ui.api.flocx.get')
     def test_get_offers(self, mock_get):
-        testData = get_test_data('offer_list_response')
+        testData = get_test_data('offer_list')
 
         mock_response = MockResponse()
         string_data = json.dumps(testData)
@@ -19,3 +19,53 @@ class RestApiTests(test.TestCase):
 
         output = offer_list()
         self.assertEqual(output, testData)
+
+    @mock.patch('flocx_ui.api.flocx.post')
+    def test_create_offer(self, mock_post):
+        testData = get_test_data('offer')
+
+        mock_response = MockResponse()
+        string_data = json.dumps(testData)
+        mock_response.status_code = 201
+        mock_response.content = string_data
+
+        mock_post.return_value = mock_response
+
+        output = offer_create(testData)
+        self.assertEqual(output, testData)
+
+    def test_create_invalid_offer(self):
+        testOffer = get_test_data('invalid_offer')
+
+        try:
+            offer_create(testOffer)
+            self.fail() # Above code should fail
+        except AjaxError as err:
+            status_code, msg = err.http_status, str(err)
+            self.assertEqual(status_code, 400)
+            self.assertEqual(msg, 'Invalid or insufficient input parameters. Cannot create offer.')
+
+    @mock.patch('flocx_ui.api.flocx.get')
+    def test_get_offer(self, mock_get):
+        testOffer = get_test_data('offer')
+        testId = testOffer['marketplace_offer_id']
+
+        mock_response = MockResponse()
+        string_data = json.dumps(testOffer)
+        mock_response.status_code = 200
+        mock_response.content = string_data
+
+        mock_get.return_value = mock_response
+
+        output = offer_get(testId)
+        self.assertEqual(output, testOffer)
+
+    def test_get_offer_invalid_id(self):
+        invalid_offer_id = 'invalid_offer'
+        try:
+            offer_get(invalid_offer_id)
+            self.fail() # Above code should fail
+        except AjaxError as err:
+            status_code, msg = err.http_status, str(err)
+            self.assertEqual(status_code, 400)
+            self.assertEqual(msg, 'Invalid Offer id.')

--- a/flocx_ui/test/tests/test_schema.py
+++ b/flocx_ui/test/tests/test_schema.py
@@ -1,0 +1,91 @@
+from unittest import TestCase
+from schema import SchemaError
+
+from flocx_ui.api.schema import (validate_uuid,
+                                 validate_date,
+                                 validate_offer_status,
+                                 validate_offer)
+
+class SchemaTests(TestCase):
+    def test_valid_uuid(self):
+        valid_uuid = '5dbdf9ab-4720-4549-8560-71135062fc4b'
+        self.assertTrue(validate_uuid(valid_uuid))
+
+    def test_invalid_uuid(self):
+        invalid_uuid = 'invalid_uuid'
+        try:
+            validate_uuid(invalid_uuid)
+            self.fail() # The above code should fail
+        except SchemaError as err:
+            self.assertIsNotNone(err)
+
+    def test_valid_date(self):
+        valid_date = '(2016-07-16T19:20:30-04:00)'
+        self.assertTrue(validate_date(valid_date))
+
+    def test_invalid_date(self):
+        # Test a date that is completely invalid
+        invalid_date1 = 'invalid_date'
+        try:
+            validate_date(invalid_date1)
+            self.fail() # The above code should fail
+        except SchemaError as err:
+            self.assertEqual(str(err), 'invalid_date is not a valid date')
+
+        # Test a date that is only formatted incorrectly
+        invalid_date2 = '2016-7-16'
+        try:
+            validate_date(invalid_date2)
+            self.fail() # The above code should fail
+        except SchemaError as err:
+            self.assertIsNotNone(err)
+
+    def test_valid_offer_status(self):
+        valid_offer = 'available'
+        self.assertTrue(validate_offer_status(valid_offer))
+
+    def test_invalid_offer_status(self):
+        invalid_offer = 'invalid_offer'
+        try:
+            validate_offer_status(invalid_offer)
+            self.fail() # The above code should fail
+        except SchemaError as err:
+            self.assertIsNotNone(err)
+
+    def test_valid_offer(self):
+        valid_offer = {
+            'marketplace_offer_id': 'b711b1ca-a77e-4392-a9b5-dc84c4f469ac',
+            'provider_offer_id': '90894712-3b21-4bf7-9899-b4234530ff8b',
+            'provider_id': 'b9752cc0-9bed-4f1c-8917-12ade7a6fdbe',
+            'project_id': '12a59a51-b4d6-497d-9f75-f56c409305c8',
+            'marketplace_date_created': '(2016-07-16T19:20:30-04:00)',
+            'status': 'available',
+            'server_id': 'fb878e3e-9425-4285-babf-0e58a7b091b2',
+            'start_time': '(2016-07-16T19:20:30-04:00)',
+            'end_time': '(2016-08-16T19:20:30-04:00)',
+            'server_config': {
+                'any_properties': True
+            },
+            'cost': 11
+        }
+        self.assertTrue(validate_offer(valid_offer))
+
+    def test_invalid_offer(self):
+        invalid_offer = {
+            'this_is_invalid': True
+        }
+        try:
+            validate_offer(invalid_offer)
+            self.fail() # The above code should fail
+        except SchemaError as err:
+            self.assertIsNotNone(err)
+
+    def test_invalid_offer_toggle_error(self):
+        invalid_offer = {
+            'this_is_invalid': True
+        }
+
+        try:
+            self.assertFalse(validate_offer(invalid_offer, return_boolean=True))
+        except SchemaError:
+            self.fail() # Should not raise an exception

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flocx-ui",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Flocx plugin for horizon to show and create bids, offers, and contracts",
   "scripts": {
     "postinstall": "if [ ! -d .tox ] || [ ! -d .tox/py37 ]; then tox -epy37 --notest; fi",

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ Django==2.0.13
 horizon>=15.1.0
 python-dotenv>=0.10.3
 requests>=2.22.0
+schema>=0.7.0


### PR DESCRIPTION
### Added

- VSCode files to `.gitignore`
- `api/schema.py` to validate the schema in a request to create an offer
- REST API endpoints to create an offer and get an offer's details

### Changed

- The API to work with the flocx-market directly. This meant adding an `X-Auth-Token` header along with all API calls
- Developer documentation to reflect the API changes from a mock backend to using the flocx-market directly

### Removed

- `handle_error` decorator from the flocx.py API service since it is already handled in the flocx_rest_api.py `@rest_utils.ajax` decorator
- keystone service from `docker-compose.yml` since the flocx-ui plugin will now talk directly with the flocx-market API