### PR TITLE
Create bids through UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Tab to view existing bids
+
 ## [1.1.1] - 2019-08-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Tab to view existing bids
+- Service endpoints to create bids along with necessary schema
+- "Create bid" modal that takes variable criteria
+- Methods to the JavaScript flocx API service that allow for creating bids
+
+### Changed
+
+- The way that schema errors are handled. It is now easier from the UI to see exactly what data is incorrect
+- Certain date logic that was previously in the `contract.controller.js` to be part of the date filters
+- Certain data used in tests
 
 ## [1.1.1] - 2019-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2019-08-12
+
 ### Added
 
 - Tab to view existing bids

--- a/flocx_ui/api/flocx_market.py
+++ b/flocx_ui/api/flocx_market.py
@@ -45,6 +45,16 @@ def offer_get(request, offer_id):
     data = response.json()
     return data
 
+def bid_list(request):
+    """Retrieve a list of bids
+
+    :param request: HTTP request
+    :return: A list of bids
+    """
+    response = get('/bid', token=request.user.token.id)
+    data = response.json()
+    return data
+
 def contract_list(request):
     """Retrieve a list of contracts
 

--- a/flocx_ui/api/flocx_market.py
+++ b/flocx_ui/api/flocx_market.py
@@ -1,6 +1,6 @@
-from openstack_dashboard.api.rest.utils import AjaxError
 from flocx_ui.api import schema
 from flocx_ui.api.utils import generic_market_request as generic_request
+from flocx_ui.api.utils import validate_data_with
 
 def get(path, **kwargs):
     """An alias for generic_request with the type set to 'GET'
@@ -31,17 +31,15 @@ def offer_list(request):
     data = response.json()
     return data
 
+@validate_data_with(None, schema.validate_uuid)
 def offer_get(request, offer_id):
     """Get an offer
 
-    :param offer_id: The offer id used to get the offer details
     :param request: HTTP request
-    :raises AjaxError: If the offer_id is invalid
+    :param offer_id: The offer id used to get the offer details
     :return: The offer associated with the offer_id
     """
-    if not schema.validate_uuid(offer_id, return_boolean=True):
-        raise AjaxError(400, 'Invalid Offer id.')
-    response = get('/offer/%r', token=request.user.token.id)
+    response = get('/offer/{}'.format(offer_id), token=request.user.token.id)
     data = response.json()
     return data
 
@@ -52,6 +50,18 @@ def bid_list(request):
     :return: A list of bids
     """
     response = get('/bid', token=request.user.token.id)
+    data = response.json()
+    return data
+
+@validate_data_with(None, schema.validate_bid)
+def bid_create(request, bid):
+    """Create a bid
+
+    :param request: HTTP Request
+    :param bid: The bid to be created
+    :return: The bid that was created
+    """
+    response = post('/bid', json=bid, token=request.user.token.id)
     data = response.json()
     return data
 

--- a/flocx_ui/api/flocx_provider.py
+++ b/flocx_ui/api/flocx_provider.py
@@ -1,8 +1,6 @@
-import json
-
-from openstack_dashboard.api.rest.utils import AjaxError
 from flocx_ui.api import schema
 from flocx_ui.api.utils import generic_provider_request as generic_request
+from flocx_ui.api.utils import validate_data_with
 
 def post(path, **kwargs):
     """An alias for generic_request with the type set to 'POST'
@@ -13,17 +11,14 @@ def post(path, **kwargs):
     """
     return generic_request('POST', path, **kwargs)
 
-def offer_create(request, offer_bytes):
+@validate_data_with(None, schema.validate_provider_offer)
+def offer_create(request, offer):
     """Create an offer
 
-    :param offer_bytes: The offer to be created
     :param request: HTTP request
-    :raises AjaxError: If the offer param is invalid
+    :param offer: The offer to be created
     :return: The offer that was created
     """
-    offer = json.loads(offer_bytes.decode('UTF-8'))
-    if not schema.validate_provider_offer(offer, return_boolean=True):
-        raise AjaxError(400, 'Invalid or insufficient input parameters. Cannot create offer.')
     response = post('/v1/offers', json=offer, token=request.user.token.id)
     data = response.json()
     return data

--- a/flocx_ui/api/flocx_rest_api.py
+++ b/flocx_ui/api/flocx_rest_api.py
@@ -50,6 +50,21 @@ class Offer(generic.View):
         return offer
 
 @urls.register
+class Bids(generic.View):
+
+    url_regex = r'flocx/bid/$'
+
+    @rest_utils.ajax()
+    def get(self, request):
+        """Get the list of bids
+
+        :param request: HTTP request
+        :return: List of bids
+        """
+        bids = flocx_market.bid_list(request)
+        return bids
+
+@urls.register
 class Contracts(generic.View):
 
     url_regex = r'flocx/contract/$'

--- a/flocx_ui/api/flocx_rest_api.py
+++ b/flocx_ui/api/flocx_rest_api.py
@@ -64,6 +64,17 @@ class Bids(generic.View):
         bids = flocx_market.bid_list(request)
         return bids
 
+    @rest_utils.ajax()
+    def post(self, request):
+        """Create a bid
+
+        :param request: The request passed into the ajax decorator
+        :return: The created bid
+        """
+        bid_data = request.body
+        bid = flocx_market.bid_create(request, bid_data)
+        return bid
+
 @urls.register
 class Contracts(generic.View):
 

--- a/flocx_ui/api/schema.py
+++ b/flocx_ui/api/schema.py
@@ -102,7 +102,7 @@ def validate_offer_status(status):
     return Schema(And(Use(lambda s: [s]), status_enum)).validate(status)
 
 @return_boolean_decorator
-def validate_offer(offer):
+def validate_offer(offer, **_kwargs):
     """Determines if an offer dictionary is valid
 
     :param offer: The offer to be validated
@@ -144,3 +144,25 @@ def validate_provider_offer(offer, **_kwargs):
         'end_date': validate_date,
         'properties': object
     }).validate(offer)
+
+@return_boolean_decorator
+def validate_bid(bid, **_kwargs):
+    """Determines if a bid dictionary is valid
+
+    :param bid: The bid to be validated
+    :param **kwargs: See below
+    :return: True if the schema is valid. Raises a SchemaError otherwise
+
+    :Keyword Arguments:
+        * return_boolean:
+            Whether to raise a SchemaError or return false if the bid is invalid
+    """
+    return Schema({
+        'start_time': validate_date,
+        'end_time': validate_date,
+        'duration': Or(int, float),
+        'server_quantity': int,
+        'status': validate_offer_status,
+        'server_config_query': object,
+        'cost': Or(int, float)
+    }).validate(bid)

--- a/flocx_ui/api/utils.py
+++ b/flocx_ui/api/utils.py
@@ -1,8 +1,11 @@
 import os
+import json
 import requests
 
 from requests.compat import urljoin
+from openstack_dashboard.api.rest.utils import AjaxError
 from dotenv import load_dotenv
+from schema import SchemaError
 
 load_dotenv(override=True)
 
@@ -76,3 +79,50 @@ def generic_provider_request(method, path, **kwargs):
     """
 
     return generic_request(method, urljoin(PROVIDER_BASE_URL, path), **kwargs)
+
+def validate_data_with(*validators):
+    """A decorator to convert and validate JSON data from incoming requests.
+       This decorator should be used to convert byte data coming in from a
+       REST API endpoint as well as validate each data arg against a given
+       validator.
+
+    :raises AjaxError: If one of the validators doesn't pass with the given data
+    :return: The decorated function that will receive the data in JSON format
+             instead of byte data
+    """
+    def decorator(func):
+        """The actual decorator function that decorates the inputted function
+
+        :param func: The function that is going to be decorated
+        :raises AjaxError: If one of the validators doesn't pass with the given data
+        :return: A wrapped function that calls the inputted func when called
+        """
+        def _wrapped(*possible_byte_data, **_kwargs):
+            """The function that takes the place of the original function and houses
+               all of the conversion and validation logic
+
+            :raises AjaxError: If one of the validators doesn't pass with the given data
+            :return: A call to the original function with JSON args instead of byte data
+            """
+            func_args = []
+            for validator, datum in zip(validators, possible_byte_data):
+                if validator is not None: # Don't try to parse as JSON if the validator is None
+
+                    # Attempt to decode bytes
+                    try:
+                        datum = json.loads(datum.decode('UTF-8'))
+                    except (AttributeError, ValueError):
+                        pass
+
+                    # Attempt validators
+                    try:
+                        validator(datum)
+                        func_args.append(datum)
+                    except SchemaError as err:
+                        raise AjaxError(400, str(err))
+                else:
+                    # Add the datum as-is to the func args
+                    func_args.append(datum)
+            return func(*func_args, **_kwargs)
+        return _wrapped
+    return decorator

--- a/flocx_ui/static/dashboard/project/flocx/bid-list/bid-list.controller.js
+++ b/flocx_ui/static/dashboard/project/flocx/bid-list/bid-list.controller.js
@@ -6,15 +6,28 @@
     .controller('BidListController', BidListController);
 
   BidListController.$inject = [
-    'horizon.app.core.openstack-service-api.flocx'
+    'horizon.app.core.openstack-service-api.flocx',
+    'horizon.dashboard.project.flocx.create-bid.service'
   ];
 
-  function BidListController(flocx) {
+  function BidListController(flocx, createBidService) {
     var ctrl = this;
 
+    ctrl.createBid = createBid;
     ctrl.bids = [];
 
     init();
+
+    /**
+     * @description Open a modal that guides a user through creating a bid
+     *
+     * @returns {void}
+     */
+    function createBid () {
+      // Open the modal
+      createBidService.createBid()
+        .then(init); // Refresh the bids
+    }
 
     function init () {
       retrieveBids();

--- a/flocx_ui/static/dashboard/project/flocx/bid-list/bid-list.controller.js
+++ b/flocx_ui/static/dashboard/project/flocx/bid-list/bid-list.controller.js
@@ -1,0 +1,32 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.dashboard.project.flocx')
+    .controller('BidListController', BidListController);
+
+  BidListController.$inject = [
+    'horizon.app.core.openstack-service-api.flocx'
+  ];
+
+  function BidListController(flocx) {
+    var ctrl = this;
+
+    ctrl.bids = [];
+
+    init();
+
+    function init () {
+      retrieveBids();
+    }
+
+    function retrieveBids () {
+      // Get the list of contracts from the flocx-market
+      flocx.getBids().then(onGetBids);
+    }
+
+    function onGetBids (bids) {
+      ctrl.bids = bids;
+    }
+  }
+}());

--- a/flocx_ui/static/dashboard/project/flocx/bid-list/bid-list.html
+++ b/flocx_ui/static/dashboard/project/flocx/bid-list/bid-list.html
@@ -1,0 +1,32 @@
+<div ng-controller="BidListController as ctrl">
+  <div class="col-lg-10">
+    <h3 style="margin: 24px 0;">Bids</h3>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Node name</th>
+          <th scope="col">Status</th>
+          <th scope="col">Quantity</th>
+          <th scope="col">Start Time</th>
+          <th scope="col">End Time</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="bid in ctrl.bids">
+          <td>{$ bid.marketplace_bid_id $}</td>
+          <td>{$ bid.status $}</td>
+          <td>{$ bid.server_quantity $}</td>
+          <td>{$ bid.start_time $}</td>
+          <td>{$ bid.end_time $}</td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td>
+            <b>Displaying {$ ctrl.bids.length $} items</b>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</div>

--- a/flocx_ui/static/dashboard/project/flocx/bid-list/bid-list.html
+++ b/flocx_ui/static/dashboard/project/flocx/bid-list/bid-list.html
@@ -1,10 +1,25 @@
 <div ng-controller="BidListController as ctrl">
   <div class="col-lg-10">
-    <h3 style="margin: 24px 0;">Bids</h3>
+    <div>
+      <div class="col-xs-6" style="padding: 0;">
+        <h3 style="margin: 24px 0;">Bids</h3>
+      </div>
+      <div class="col-xs-6" style="padding: 0;">
+        <button
+          class="btn btn-default pull-right"
+          style="margin: 24px 0;"
+          type="button"
+          ng-click="ctrl.createBid()"
+        >
+          <i class="fa fa-plus"></i>
+          Create Bid
+        </button>
+      </div>
+    </div>
     <table class="table">
       <thead>
         <tr>
-          <th scope="col">Node name</th>
+          <th scope="col">Bid ID</th>
           <th scope="col">Status</th>
           <th scope="col">Quantity</th>
           <th scope="col">Start Time</th>
@@ -16,8 +31,8 @@
           <td>{$ bid.marketplace_bid_id $}</td>
           <td>{$ bid.status $}</td>
           <td>{$ bid.server_quantity $}</td>
-          <td>{$ bid.start_time $}</td>
-          <td>{$ bid.end_time $}</td>
+          <td>{$ bid.start_time | utcToLocal:'short' $}</td>
+          <td>{$ bid.end_time | utcToLocal:'short' $}</td>
         </tr>
       </tbody>
       <tfoot>

--- a/flocx_ui/static/dashboard/project/flocx/contract-list/contract-list.controller.js
+++ b/flocx_ui/static/dashboard/project/flocx/contract-list/contract-list.controller.js
@@ -49,11 +49,7 @@
 
     function filterContracts (contracts) {
       // Filter the contracts depending on the active tab
-      ctrl.contracts = contracts.filter(filter).map(function (contract) {
-        contract.start_time = new Date(contract.start_time).toLocaleString();
-        contract.end_time = new Date(contract.end_time).toLocaleString();
-        return contract;
-      });
+      ctrl.contracts = contracts.filter(filter);
     }
 
     function filter (contract) {

--- a/flocx_ui/static/dashboard/project/flocx/contract-list/contract-list.html
+++ b/flocx_ui/static/dashboard/project/flocx/contract-list/contract-list.html
@@ -33,8 +33,8 @@
         <tr ng-repeat="contract in ctrl.contracts">
           <td>{$ contract.contract_id $}</td>
           <td>{$ contract.status $}</td>
-          <td>{$ contract.start_time $}</td>
-          <td>{$ contract.end_time $}</td>
+          <td>{$ contract.start_time | utcToLocal:'short' $}</td>
+          <td>{$ contract.end_time | utcToLocal:'short' $}</td>
           <td>{$ contract.cost $}</td>
         </tr>
       </tbody>

--- a/flocx_ui/static/dashboard/project/flocx/create-bid/create-bid.controller.js
+++ b/flocx_ui/static/dashboard/project/flocx/create-bid/create-bid.controller.js
@@ -1,0 +1,192 @@
+(function() {
+  'use strict';
+
+  /**
+   * Controller used to create a bid
+   */
+  angular
+    .module('horizon.dashboard.project.flocx')
+    .controller('CreateBidController', CreateBidController);
+
+  CreateBidController.$inject = [
+    '$filter',
+    '$uibModalInstance',
+    'horizon.app.core.openstack-service-api.flocx',
+    'horizon.dashboard.project.flocx.hourRegex',
+    'horizon.dashboard.project.flocx.defaultBidDaysDifference',
+    'horizon.dashboard.project.flocx.defaultBidQuantity',
+    'horizon.dashboard.project.flocx.quantityRegex',
+    'horizon.dashboard.project.flocx.defaultBidCost',
+    'horizon.dashboard.project.flocx.costRegex',
+    'horizon.dashboard.project.flocx.baseNode',
+    'horizon.dashboard.project.flocx.availableBidStatus',
+    'horizon.framework.widgets.toast.service'
+  ];
+
+  function CreateBidController($filter,
+                               $uibModalInstance,
+                               flocx,
+                               hourRegex,
+                               bidDaysDifference,
+                               defaultQuantity,
+                               quantityPattern,
+                               defaultCost,
+                               costPattern,
+                               baseNode,
+                               availableBidStatus,
+                               toastService) {
+    var ctrl = this;
+
+    // Import filters from date.filter.js
+    var nextHourString = $filter('nextHourString');
+    var convertToDatetime = $filter('convertToDatetime');
+
+    var localeOptions = {
+      month: '2-digit',
+      day: '2-digit',
+      year: 'numeric'
+    };
+    var today = new Date();
+    var endDateMs = (new Date()).setDate(today.getDate() + bidDaysDifference);
+    var endDate = new Date(endDateMs);
+    var todayString = today.toLocaleDateString(undefined, localeOptions);
+    var endDateString = endDate.toLocaleDateString(undefined, localeOptions);
+    var todayTimeString = nextHourString(today);
+    var endDateTimeString = nextHourString(endDate);
+
+    ctrl.startDate = todayString;
+    ctrl.endDate = endDateString;
+    ctrl.startTime = todayTimeString;
+    ctrl.endTime = endDateTimeString;
+    ctrl.hourPattern = hourRegex;
+    ctrl.quantity = defaultQuantity;
+    ctrl.quantityPattern = quantityPattern;
+    ctrl.cost = defaultCost;
+    ctrl.costPattern = costPattern;
+
+    var operators = [
+      {
+        name: 'Numeric operators',
+        options: [ '==', '!=', '>', '<', '>=', '<=' ]
+      },
+      {
+        name: 'String operators',
+        options: [ 'eq', 'ne', 'startswith', 'endswith', 'matches' ]
+      },
+      {
+        name: 'List operators',
+        options: [ 'in', 'contains' ]
+      }
+    ];
+
+    /** Convert `operators` to a format for Angular to read
+     *
+     * This will change it from an array of objects
+     * containing arrays to an array of objects
+     */
+    ctrl.operators = operators.map(function (operator) {
+      return operator.options.map(function (option) {
+        return {
+          group: operator.name,
+          option: option
+        };
+      });
+    }).reduce(function (arr, objects) {
+      return arr.concat(objects);
+    }, []);
+
+    ctrl.match_criteria = baseNode;
+    ctrl.addRow = addRow;
+    ctrl.removeRow = removeRow;
+    ctrl.createBid = createBid;
+
+    /**
+     * @description Add a row to the ctrl.match_critera
+     *
+     * @returns {void}
+     */
+    function addRow () {
+      ctrl.match_criteria.push(['', '==', '']);
+    }
+
+    /**
+     * @description Remove a row from the ctrl.match_criteria
+     * @param {number} index The index to be removed from the criteria
+     *
+     * @returns {void}
+     */
+    function removeRow (index) {
+      ctrl.match_criteria.splice(index, 1);
+    }
+
+    /**
+     * @description Determine if a string or array of strings is/are empty
+     * @param {*} stringLikeVar A string-like variable or array of string-like variables
+     *
+     * @returns {boolean} Whether the input is empty
+     */
+    function isNotEmpty (stringLikeVar) {
+      if (Array.isArray(stringLikeVar)) {
+        return stringLikeVar.every(isNotEmpty);
+      }
+
+      return stringLikeVar.toString().length > 0;
+    }
+
+    /**
+     * @description Filter out criteria that are empty
+     * @param {*} criteria An array of criteria
+     *
+     * @returns {*} A filtered list of the criteria by whether or not they are empty
+     */
+    function filterEmptyCriteria (criteria) {
+      return criteria.filter(isNotEmpty).map(function (criterion) {
+        return Array.from(criterion); // Array.from gets rid of Angular properties like `$$hashKey`
+      });
+    }
+
+    /**
+     * @description Display a notification when a bid creation error occurs
+     * @param {*} err The error text to be displayed
+     *
+     * @return {void}
+     */
+    function displayBidCreationError (err) {
+      toastService.add('error', 'Failed to create bid. ' + err);
+    }
+
+    /**
+     * Create the defined bid
+     *
+     * @return {promise} A promise that resolves when the bid is created
+     */
+    function createBid () {
+      var bid;
+
+      try {
+        bid = {
+          server_quantity: +ctrl.quantity,
+          start_time: convertToDatetime(ctrl.startDate, ctrl.startTime),
+          end_time: convertToDatetime(ctrl.endDate, ctrl.endTime),
+          status: availableBidStatus,
+          duration: 10, // duration is not used right now
+          server_config_query: {
+            specs: filterEmptyCriteria(ctrl.match_criteria)
+          },
+          cost: +ctrl.cost
+        };
+      } catch (err) {
+        return displayBidCreationError(err);
+      }
+
+      // Attempt to create the bid
+      return flocx.createBid(bid)
+        .then(function (createdBid) {
+          $uibModalInstance.close(createdBid);
+        })
+        .catch(function (error) {
+          displayBidCreationError(error.data);
+        });
+    }
+  }
+}());

--- a/flocx_ui/static/dashboard/project/flocx/create-bid/create-bid.controller.spec.js
+++ b/flocx_ui/static/dashboard/project/flocx/create-bid/create-bid.controller.spec.js
@@ -1,0 +1,57 @@
+(function () {
+  'use strict';
+
+  describe('CreateBidController', function () {
+    var ctrl;
+
+    beforeAll(function () {
+      // Mock the Date object to use a constant time
+      jasmine.clock().install();
+      var baseTime = new Date(2019, 7, 2);
+      jasmine.clock().mockDate(baseTime);
+    });
+
+    afterAll(function () {
+      // Remove the date mocks
+      jasmine.clock().uninstall();
+    });
+
+    beforeEach(module('horizon.dashboard.project.flocx'));
+
+    beforeEach(module('horizon.framework.util'));
+
+    beforeEach(module(function($provide) {
+      $provide.value('$uibModalInstance', {});
+    }));
+
+    beforeEach(module(function($provide) {
+      $provide.value('horizon.framework.widgets.toast.service',
+                     {});
+    }));
+
+    beforeEach(module('horizon.app.core.openstack-service-api'));
+
+    beforeEach(inject(function($injector) {
+      var controller = $injector.get('$controller');
+      ctrl = controller('CreateBidController');
+    }));
+
+    it('controller should be defined', function () {
+      expect(ctrl).toBeDefined();
+    });
+
+    it('should mock native Date', function () {
+      expect(new Date().toISOString()).toEqual('2019-08-02T04:00:00.000Z');
+    });
+
+    it('controller base construction', function () {
+      /**
+       * Ensure that the controller can successfully set it's properties
+       */
+      expect(ctrl.startDate).toEqual('August 2, 2019');
+      expect(ctrl.endDate).toEqual('August 9, 2019');
+      expect(ctrl.startTime).toContain('12:00:00 AM');
+      expect(ctrl.endTime).toContain('12:00:00 AM');
+    });
+  });
+}());

--- a/flocx_ui/static/dashboard/project/flocx/create-bid/create-bid.html
+++ b/flocx_ui/static/dashboard/project/flocx/create-bid/create-bid.html
@@ -1,0 +1,218 @@
+<div class="modal-header" modal-draggable>
+  <button type="button"
+          class="close"
+          ng-click="$dismiss()"
+          aria-hidden="true"
+          aria-label="Close">
+    <span aria-hidden="true" class="fa fa-times"></span>
+  </button>
+  <h3 class="modal-title">Create a bid</h3>
+</div>
+<div class="modal-body">
+  <form class="form-horizontal" name="bidForm" action="javascript:void(0);">
+    <div class="form-group">
+      <div class="container-fluid">
+        <div class="col-sm-5 input-daterange" data-provide="datepicker">
+          <div class="form-group">
+            <label class="col-sm-4 control-label" for="bid-start-datepicker">Start date</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+                <span class="add-on input-group-addon">
+                  <span class="fa fa-calendar"></span>
+                </span>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="bid-start-datepicker"
+                  placeholder="Select date"
+                  ng-model="ctrl.startDate"
+                  required
+                >
+              </div>
+            </div>
+          </div>
+          <div class="form-group">
+            <label class="col-sm-4 control-label" for="bid-end-datepicker">End date</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+                <span class="add-on input-group-addon">
+                  <span class="fa fa-calendar"></span>
+                </span>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="bid-end-datepicker"
+                  placeholder="Select date"
+                  ng-model="ctrl.endDate"
+                  required
+                >
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-7">
+          <div class="form-group" ng-class="{ 'has-error': bidForm.$dirty && !bidForm.bidStartTime.$valid }">
+            <label class="col-sm-3 control-label" for="bid-start-time">Start time</label>
+            <div class="col-sm-4">
+              <input
+                name="bidStartTime"
+                class="form-control"
+                id="bid-start-time"
+                placeholder="9 AM"
+                ng-model="ctrl.startTime"
+                ng-pattern="ctrl.hourPattern"
+                style="max-width: 120px;"
+                required
+              >
+            </div>
+          </div>
+          <div class="form-group" ng-class="{ 'has-error': bidForm.$dirty && !bidForm.bidEndTime.$valid }">
+            <label class="col-sm-3 control-label" for="bid-end-time">End time</label>
+            <div class="col-sm-4">
+              <input
+                name="bidEndTime"
+                class="form-control"
+                id="bid-end-time"
+                placeholder="9 AM"
+                ng-model="ctrl.endTime"
+                ng-pattern="ctrl.hourPattern"
+                style="max-width: 120px;"
+                required
+              >
+            </div>
+          </div>
+        </div>
+        <p class="help-block">Start and end time should be whole hours.</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-xs-6">
+        <h4>Criteria</h4>
+      </div>
+      <div class="col-xs-6">
+        <button
+          type="button"
+          class="btn btn-link pull-right"
+          ng-click="ctrl.addRow()"
+        >
+          + Add Row
+        </button>
+      </div>
+    </div>
+    <!-- Headers -->
+    <div class="container-fluid">
+      <div class="col-xs-4">
+        <h6>Expression</h6>
+      </div>
+      <div class="col-xs-2">
+        <h6>Operator</h6>
+      </div>
+      <div class="col-xs-6">
+        <h6>Value</h6>
+      </div>
+    </div>
+    <!-- Matcher Fields -->
+    <div>
+      <div
+        class="container-fluid"
+        ng-repeat="criterion in ctrl.match_criteria"
+        style="margin-bottom: 24px;"
+      >
+        <div class="col-xs-4">
+          <input
+            type="text"
+            class="form-control"
+            ng-model="ctrl.match_criteria[$index][0]"
+            required
+          >
+        </div>
+        <div class="col-xs-2">
+          <select
+            class="form-control"
+            ng-options="operator.option as operator.option group by operator.group for operator in ctrl.operators track by operator.option"
+            ng-model="ctrl.match_criteria[$index][1]"
+            required
+          >
+          </select>
+        </div>
+        <div class="col-xs-6" style="display: flex;">
+          <input
+            type="text"
+            class="form-control"
+            ng-model="ctrl.match_criteria[$index][2]"
+            required
+          >
+          <button type="button"
+            class="close"
+            style="margin-left: 12px;"
+            ng-click="ctrl.removeRow($index)"
+            aria-hidden="true"
+            aria-label="Close"
+          >
+            <span aria-hidden="true" class="fa fa-times"></span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <hr>
+    <div class="row">
+      <div class="col-xs-5">
+          <div class="form-group">
+            <label class="col-sm-3 control-label" for="bid-cost">Cost</label>
+            <div class="col-sm-5">
+              <input
+                name="bidCost"
+                class="form-control"
+                id="bid-cost"
+                ng-model="ctrl.cost"
+                ng-pattern="ctrl.costPattern"
+                required
+              >
+            </div>
+          </div>
+      </div>
+      <div class="col-xs-4">
+        <div class="form-group">
+          <label class="col-sm-3 control-label" for="bid-quantity">Quantity</label>
+          <div class="col-sm-5">
+            <input
+              name="bidQuantity"
+              class="form-control"
+              id="bid-quantity"
+              ng-model="ctrl.quantity"
+              ng-pattern="ctrl.quantityPattern"
+              required
+            >
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="alert alert-danger"
+      role="alert"
+      ng-show="bidForm.$error.required"
+    >Some required data is missing.</div>
+    <div
+      class="alert alert-danger"
+      role="alert"
+      ng-show="bidForm.$dirty && !(bidForm.bidStartTime.$valid && bidForm.bidEndTime.$valid)"
+    >The hours entered do not match the required format.</div>
+    <div
+      class="alert alert-danger"
+      role="alert"
+      ng-show="bidForm.$dirty && !bidForm.bidCost.$valid"
+    >The cost eneterd does not match the required format.</div>
+    <div
+      class="alert alert-danger"
+      role="alert"
+      ng-show="bidForm.$dirty && !bidForm.bidQuantity.$valid"
+    >The quantity eneterd does not match the required format.</div>
+  </form>
+</div>
+<div class="modal-footer">
+  <button
+    type="button" 
+    class="btn btn-primary"
+    ng-disabled="bidForm.$dirty && !bidForm.$valid"
+    ng-click="ctrl.createBid()">Create bid</button>
+</div>

--- a/flocx_ui/static/dashboard/project/flocx/create-bid/create-bid.service.js
+++ b/flocx_ui/static/dashboard/project/flocx/create-bid/create-bid.service.js
@@ -1,0 +1,34 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('horizon.dashboard.project.flocx')
+    .factory('horizon.dashboard.project.flocx.create-bid.service',
+             createBidService);
+
+  createBidService.$inject = [
+    '$uibModal',
+    'horizon.dashboard.project.flocx.basePath'
+  ];
+
+  function createBidService($uibModal, basePath) {
+    var service = {
+      createBid: createBid
+    };
+    return service;
+
+    /**
+     * @description Launch a modal dialog that will guide the user
+     * in creating a new bid
+     *
+     * @return {promise} Object describing the created bid
+     */
+    function createBid () {
+      var options = {
+        controller: 'CreateBidController as ctrl',
+        templateUrl: basePath + '/create-bid/create-bid.html'
+      };
+      return $uibModal.open(options).result;
+    }
+  }
+}());

--- a/flocx_ui/static/dashboard/project/flocx/create-offer/create-offer.controller.js
+++ b/flocx_ui/static/dashboard/project/flocx/create-offer/create-offer.controller.js
@@ -31,8 +31,9 @@
                                 node) {
     var ctrl = this;
 
-    // Import time filter from date.filter.js
-    var dateToUTC = $filter('dateToUTC');
+    // Import filters from date.filter.js
+    var nextHourString = $filter('nextHourString');
+    var convertToDatetime = $filter('convertToDatetime');
 
     var localeOptions = {
       month: '2-digit',
@@ -44,8 +45,8 @@
     var endDate = new Date(endDateMs);
     var todayString = today.toLocaleDateString(undefined, localeOptions);
     var endDateString = endDate.toLocaleDateString(undefined, localeOptions);
-    var todayTimeString = getNextHourString(today);
-    var endDateTimeString = getNextHourString(endDate);
+    var todayTimeString = nextHourString(today);
+    var endDateTimeString = nextHourString(endDate);
     var config = node.properties;
 
     ctrl.name = node.name || node.uuid;
@@ -59,34 +60,6 @@
     ctrl.defaultCost = offerCost;
     ctrl.hourPattern = hourRegex;
     ctrl.costPattern = costRegex;
-
-    /**
-     * @description Get the next hour after a given date as a string of the form: [hh AM/PM]
-     * @param {Date} date The JavaScript date given
-     * @returns {string} A string interpretation of the next hour
-     */
-    function getNextHourString (date) {
-      date.setHours(date.getHours() + Math.ceil(date.getMinutes() / 60));
-      date.setMinutes(0);
-
-      var timeString = date.toLocaleTimeString([], { hour: 'numeric' });
-      return timeString;
-    }
-
-    /**
-     * @description Convert a JavaScript date string string to a MySQL compatible format
-     * @param {string} dateString The date used in the created date
-     * @param {string} timeString The time used in the created date
-     *
-     * @returns {string} A MySQL compatible datetime string
-     */
-    function convertToDatetime (dateString, timeString) {
-      // Add `:00` to the time (from 9 AM to 9:00 AM) to make it compatible with JavaScript Date
-      var modifiedTimeString = timeString.slice(0, -3) + ':00' + timeString.slice(-3);
-      var compatibleDate = dateString + ' ' + modifiedTimeString;
-
-      return dateToUTC(new Date(compatibleDate));
-    }
 
     /**
      * @description Display a notification when an offer creation error occurs
@@ -123,7 +96,7 @@
 
       // Attempt to create the offer
       return flocx.createOffer(offer)
-        .then(function(createdOffer) {
+        .then(function (createdOffer) {
           $uibModalInstance.close(createdOffer);
         })
         .catch(function (error) {

--- a/flocx_ui/static/dashboard/project/flocx/flocx.backend-mock.service.js
+++ b/flocx_ui/static/dashboard/project/flocx/flocx.backend-mock.service.js
@@ -100,6 +100,7 @@
       flush: flush,
       postTest: postTest,
       _sampleOffers: sampleOffers,
+      _sampleBids: sampleBids,
       _sampleContracts: sampleContracts
     };
 
@@ -125,6 +126,10 @@
       // Get bids
       $httpBackend.whenGET('/api/flocx/bid/')
         .respond(responseCode.SUCCESS, sampleBids);
+
+      // Create bid
+      $httpBackend.whenPOST('/api/flocx/bid/')
+        .respond(responseCode.SUCCESS, sampleBids[0]);
 
       // Get contracts
       $httpBackend.whenGET('/api/flocx/contract/')

--- a/flocx_ui/static/dashboard/project/flocx/flocx.backend-mock.service.js
+++ b/flocx_ui/static/dashboard/project/flocx/flocx.backend-mock.service.js
@@ -59,6 +59,24 @@
       }
     ];
 
+    var sampleBids = [
+      {
+        marketplace_bid_id: "8f9d6482-e308-41af-acef-5a415a636d5d",
+        project_id: "4d02370751104210bc5de88a4d9898f5",
+        server_quantity: 80,
+        start_time: "2019-07-24T13:59:14",
+        end_time: "2019-07-24T13:59:14",
+        duration: 16400,
+        status: "active",
+        server_config_query: {
+          foo: "bar"
+        },
+        cost: 11.0,
+        created_at: "2019-08-01T16:56:34",
+        updated_at: "2019-08-07T18:24:18"
+      }
+    ];
+
     var sampleContracts = [
       {
         contract_id: "b711b1ca-a77e-4392-abcd-dc84c4f469ac",
@@ -100,8 +118,13 @@
       $httpBackend.whenGET('/api/flocx/offer/')
         .respond(responseCode.SUCCESS, sampleOffers);
 
+      // Create offer
       $httpBackend.whenPOST('/api/flocx/offer/')
         .respond(responseCode.SUCCESS, sampleOffers[0]);
+
+      // Get bids
+      $httpBackend.whenGET('/api/flocx/bid/')
+        .respond(responseCode.SUCCESS, sampleBids);
 
       // Get contracts
       $httpBackend.whenGET('/api/flocx/contract/')

--- a/flocx_ui/static/dashboard/project/flocx/flocx.module.js
+++ b/flocx_ui/static/dashboard/project/flocx/flocx.module.js
@@ -22,11 +22,26 @@
 
     $provide.constant('horizon.dashboard.project.flocx.hourRegex', /^\d{1,2} [aApP][mM]$/);
 
+    $provide.constant('horizon.dashboard.project.flocx.quantityRegex', /^\d{1,3}$/);
+
     $provide.constant('horizon.dashboard.project.flocx.costRegex', /^\d{1,3}$/);
 
     $provide.constant('horizon.dashboard.project.flocx.defaultOfferDaysDifference', 7);
 
     $provide.constant('horizon.dashboard.project.flocx.defaultOfferCost', 10);
+
+    $provide.constant('horizon.dashboard.project.flocx.defaultBidDaysDifference', 7);
+
+    $provide.constant('horizon.dashboard.project.flocx.defaultBidCost', 10);
+
+    $provide.constant('horizon.dashboard.project.flocx.defaultBidQuantity', 1);
+
+    $provide.constant('horizon.dashboard.project.flocx.availableBidStatus', 'available');
+
+    $provide.constant('horizon.dashboard.project.flocx.baseNode', [
+      ['cpus', '>=', 32],
+      ['local_gb', '>=', 512]
+    ]);
 
     var path = $windowProvider.$get().STATIC_URL + 'dashboard/project/flocx/';
     $provide.constant('horizon.dashboard.project.flocx.basePath', path);

--- a/flocx_ui/static/dashboard/project/flocx/flocxApi.service.js
+++ b/flocx_ui/static/dashboard/project/flocx/flocxApi.service.js
@@ -20,6 +20,7 @@
       getOffers: getOffers,
       createOffer: createOffer,
       getBids: getBids,
+      createBid: createBid,
       getContracts: getContracts
     };
 
@@ -54,6 +55,18 @@
      */
     function getBids() {
       return apiService.get('/api/flocx/bid/')
+        .then(function (response) {
+          return response.data;
+        });
+    }
+
+    /**
+     * @description Create a bid
+     * @param {*} bid The bid data to be used when creating the bid
+     * @returns {promise} Promise containing the created offer
+     */
+    function createBid(bid) {
+      return apiService.post('/api/flocx/bid/', bid)
         .then(function (response) {
           return response.data;
         });

--- a/flocx_ui/static/dashboard/project/flocx/flocxApi.service.js
+++ b/flocx_ui/static/dashboard/project/flocx/flocxApi.service.js
@@ -19,6 +19,7 @@
     var service = {
       getOffers: getOffers,
       createOffer: createOffer,
+      getBids: getBids,
       getContracts: getContracts
     };
 
@@ -42,6 +43,17 @@
      */
     function createOffer(offer) {
       return apiService.post('/api/flocx/offer/', offer)
+        .then(function (response) {
+          return response.data;
+        });
+    }
+
+    /**
+     * @description Get a list of bids
+     * @returns {promise} Promise containing a list of bids
+     */
+    function getBids() {
+      return apiService.get('/api/flocx/bid/')
         .then(function (response) {
           return response.data;
         });

--- a/flocx_ui/static/dashboard/project/flocx/flocxApi.service.spec.js
+++ b/flocx_ui/static/dashboard/project/flocx/flocxApi.service.spec.js
@@ -61,6 +61,17 @@
           flocxBackendMockService.flush();
         });
 
+        it('getBids', function (done) {
+          flocxAPI.getBids()
+            .then(function (bids) {
+              expect(bids).toBeDefined();
+              done();
+            })
+            .catch(fail);
+
+          flocxBackendMockService.flush();
+        });
+
         it('getContracts', function (done) {
           flocxAPI.getContracts()
             .then(function (contracts) {

--- a/flocx_ui/static/dashboard/project/flocx/flocxApi.service.spec.js
+++ b/flocx_ui/static/dashboard/project/flocx/flocxApi.service.spec.js
@@ -72,6 +72,17 @@
           flocxBackendMockService.flush();
         });
 
+        it('createBid', function (done) {
+          flocxAPI.createBid(flocxBackendMockService._sampleBids[0])
+            .then(function (bid) {
+              expect(bid).toBeDefined();
+              done();
+            })
+            .catch(fail);
+
+          flocxBackendMockService.flush();
+        });
+
         it('getContracts', function (done) {
           flocxAPI.getContracts()
             .then(function (contracts) {

--- a/flocx_ui/static/dashboard/project/flocx/node-list/node-list.controller.js
+++ b/flocx_ui/static/dashboard/project/flocx/node-list/node-list.controller.js
@@ -26,13 +26,13 @@
     init();
 
     /**
-     * @description Open a modal that guids a user through creating an offer
+     * @description Open a modal that guides a user through creating an offer
      * @param {*} node The node data to be used as default values in the modal
      *
      * @returns {void}
      */
     function createOffer (node) {
-      // Open a modal that guides a user through creating an offer
+      // Open the modal
       createOfferService.createOffer(node)
         .then(init); // Refresh the nodes and offers
     }
@@ -152,7 +152,7 @@
         status = offer.status.charAt(0).toUpperCase() + offer.status.slice(1);
       }
       if (offer.end_time) {
-        expires = utcToLocal(offer.end_time, 'medium');
+        expires = utcToLocal(offer.end_time, 'short');
       }
 
       if (offer.server_config && offer.server_config.properties) {

--- a/flocx_ui/static/dashboard/project/flocx/tab-navigation/tab-navigation.controller.js
+++ b/flocx_ui/static/dashboard/project/flocx/tab-navigation/tab-navigation.controller.js
@@ -19,6 +19,10 @@
         path: 'node-list/node-list.html'
       },
       {
+        title: 'Bids',
+        path: 'bid-list/bid-list.html'
+      },
+      {
         title: 'Contracts',
         path: 'contract-list/contract-list.html'
       }

--- a/flocx_ui/test/tests/test_data.json
+++ b/flocx_ui/test/tests/test_data.json
@@ -89,6 +89,38 @@
     "status": "Error",
     "message": "Invalid or insufficient input parameters. Cannot create offer."
   },
+  "bid_list": [
+    {
+      "marketplace_bid_id": "4ed1fa43-5983-4a01-b4dd-5b3db5b76d46",
+      "project_id": "4d02370751104210bc5de88a4d9898f5",
+      "server_quantity": 80,
+      "start_time": "2019-07-24T13:59:14",
+      "end_time": "2019-07-24T13:59:14",
+      "duration": 16400,
+      "status": "expired",
+      "server_config_query": {
+        "foo": "bar"
+      },
+      "cost": 11.0,
+      "created_at": "2019-08-01T16:56:25",
+      "updated_at": "2019-08-07T18:24:18"
+    },
+    {
+      "marketplace_bid_id": "8f9d6482-e308-41af-acef-5a415a636d5d",
+      "project_id": "4d02370751104210bc5de88a4d9898f5",
+      "server_quantity": 80,
+      "start_time": "2019-07-24T13:59:14",
+      "end_time": "2019-07-24T13:59:14",
+      "duration": 16400,
+      "status": "active",
+      "server_config_query": {
+        "foo": "bar"
+      },
+      "cost": 11.0,
+      "created_at": "2019-08-01T16:56:34",
+      "updated_at": "2019-08-07T18:24:18"
+    }
+  ],
   "contract_list": [
     {
       "contract_id": "b711b1ca-a77e-4392-abcd-dc84c4f469ac",

--- a/flocx_ui/test/tests/test_data.json
+++ b/flocx_ui/test/tests/test_data.json
@@ -82,12 +82,8 @@
       ]
     }
   },
-  "invalid_offer": {
+  "invalid": {
     "this_is_invalid": true
-  },
-  "invalid_offer_error": {
-    "status": "Error",
-    "message": "Invalid or insufficient input parameters. Cannot create offer."
   },
   "bid_list": [
     {
@@ -121,6 +117,17 @@
       "updated_at": "2019-08-07T18:24:18"
     }
   ],
+  "bid": {
+    "server_quantity": 80,
+    "start_time": "2019-07-24 13:59:14",
+    "end_time": "2019-07-24 13:59:14",
+    "duration": 16400,
+    "status": "available",
+    "server_config_query": {
+      "foo": "bar"
+    },
+    "cost": 11.0
+  },
   "contract_list": [
     {
       "contract_id": "b711b1ca-a77e-4392-abcd-dc84c4f469ac",

--- a/flocx_ui/test/tests/test_flocx_rest_api.py
+++ b/flocx_ui/test/tests/test_flocx_rest_api.py
@@ -55,6 +55,18 @@ class RestApiTests(test.TestCase):
         response = offerAPI.get(request, offer_id)
         self.assertEqual(response.json, testData)
 
+    @mock.patch('flocx_ui.api.flocx_market.bid_list')
+    def test_get_bids(self, mock_bid_list):
+        testData = get_test_data('bid_list')
+        mock_bid_list.return_value = testData
+
+        rf = RequestFactory()
+        request = rf.get('/api/flocx/bid/')
+
+        bidsAPI = api.Bids()
+        response = bidsAPI.get(request)
+        self.assertEqual(response.json, testData)
+
     @mock.patch('flocx_ui.api.flocx_market.contract_list')
     def test_get_contracts(self, mock_contract_list):
         testData = get_test_data('contract_list')

--- a/flocx_ui/test/tests/test_flocx_service.py
+++ b/flocx_ui/test/tests/test_flocx_service.py
@@ -41,16 +41,39 @@ class ServiceTests(test.TestCase):
         self.assertEqual(output, testOffer)
 
     def test_create_invalid_offer(self):
-        testOffer = get_test_data('invalid_offer')
+        testOffer = get_test_data('invalid')
         testOfferBytes = str.encode(json.dumps(testOffer))
 
         try:
             flocx_provider.offer_create(mock_request, testOfferBytes)
             self.fail() # Above code should fail
         except AjaxError as err:
-            status_code, msg = err.http_status, str(err)
-            self.assertEqual(status_code, 400)
-            self.assertEqual(msg, 'Invalid or insufficient input parameters. Cannot create offer.')
+            self.assertEqual(err.http_status, 400)
+
+    @mock.patch('flocx_ui.api.flocx_market.post')
+    def test_create_bid(self, mock_post):
+        testBid = get_test_data('bid')
+        testBidBytes = str.encode(json.dumps(testBid))
+
+        mock_response = MockResponse()
+        string_data = json.dumps(testBid)
+        mock_response.status_code = 201
+        mock_response.content = string_data
+
+        mock_post.return_value = mock_response
+
+        output = flocx_market.bid_create(mock_request, testBidBytes)
+        self.assertEqual(output, testBid)
+
+    def test_create_invalid_bid(self):
+        testBid = get_test_data('invalid')
+        testBidBytes = str.encode(json.dumps(testBid))
+
+        try:
+            flocx_market.bid_create(mock_request, testBidBytes)
+            self.fail() # Above code should fail
+        except AjaxError as err:
+            self.assertEqual(err.http_status, 400)
 
     @mock.patch('flocx_ui.api.flocx_market.get')
     def test_get_offer(self, mock_get):
@@ -73,9 +96,7 @@ class ServiceTests(test.TestCase):
             flocx_market.offer_get(mock_request, invalid_offer_id)
             self.fail() # Above code should fail
         except AjaxError as err:
-            status_code, msg = err.http_status, str(err)
-            self.assertEqual(status_code, 400)
-            self.assertEqual(msg, 'Invalid Offer id.')
+            self.assertEqual(err.http_status, 400)
 
     @mock.patch('flocx_ui.api.flocx_market.get')
     def test_get_bids(self, mock_get):

--- a/flocx_ui/test/tests/test_flocx_service.py
+++ b/flocx_ui/test/tests/test_flocx_service.py
@@ -78,6 +78,19 @@ class ServiceTests(test.TestCase):
             self.assertEqual(msg, 'Invalid Offer id.')
 
     @mock.patch('flocx_ui.api.flocx_market.get')
+    def test_get_bids(self, mock_get):
+        testData = get_test_data('bid_list')
+
+        mock_response = MockResponse()
+        string_data = json.dumps(testData)
+        mock_response.content = string_data
+
+        mock_get.return_value = mock_response
+
+        output = flocx_market.bid_list(mock_request)
+        self.assertEqual(output, testData)
+
+    @mock.patch('flocx_ui.api.flocx_market.get')
     def test_get_contracts(self, mock_get):
         testData = get_test_data('contract_list')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flocx-ui",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Flocx plugin for horizon to show and create bids, offers, and contracts",
   "scripts": {
     "postinstall": "if [ ! -d .tox ] || [ ! -d .tox/py37 ]; then tox -epy37 --notest; fi",


### PR DESCRIPTION
### Added

- Tab to view existing bids
- Service endpoints to create bids along with necessary schema
- "Create bid" modal that takes variable criteria
- Methods to the JavaScript flocx API service that allow for creating bids

### Changed

- The way that schema errors are handled. It is now easier from the UI to see exactly what data is incorrect
- Certain date logic that was previously in the `contract.controller.js` to be part of the date filters
- Certain data used in tests