### PR TITLE
Default offer time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.1] - 2019-08-12
 
+### Changed
+
+- The default offer start and end times to be at the closest hour in the past instead of the next closest hour (#20).
+
 ### Fixed
 
 - A typo in the `setup.cfg` file (#24)

--- a/flocx_ui/static/dashboard/project/flocx/create-offer/create-offer.controller.js
+++ b/flocx_ui/static/dashboard/project/flocx/create-offer/create-offer.controller.js
@@ -32,7 +32,7 @@
     var ctrl = this;
 
     // Import filters from date.filter.js
-    var nextHourString = $filter('nextHourString');
+    var lastHourString = $filter('lastHourString');
     var convertToDatetime = $filter('convertToDatetime');
 
     var localeOptions = {
@@ -45,8 +45,8 @@
     var endDate = new Date(endDateMs);
     var todayString = today.toLocaleDateString(undefined, localeOptions);
     var endDateString = endDate.toLocaleDateString(undefined, localeOptions);
-    var todayTimeString = nextHourString(today);
-    var endDateTimeString = nextHourString(endDate);
+    var todayTimeString = lastHourString(today);
+    var endDateTimeString = lastHourString(endDate);
     var config = node.properties;
 
     ctrl.name = node.name || node.uuid;

--- a/flocx_ui/static/dashboard/project/flocx/date-filter/date.filter.spec.js
+++ b/flocx_ui/static/dashboard/project/flocx/date-filter/date.filter.spec.js
@@ -2,11 +2,12 @@
   'use strict';
 
   describe('Date Filter', function () {
-    var utcToLocal, dateToUTC;
+    var utcToLocal, dateToUTC, nextHourString,
+      lastHourString, convertToDatetime;
 
     beforeAll(function () {
       // Mock the Date object to use a constant time
-      var baseTime = new Date(2019, 7, 2);
+      var baseTime = new Date(2019, 7, 2, 3, 14);
       jasmine.clock().install();
       jasmine.clock().mockDate(baseTime);
     });
@@ -20,6 +21,9 @@
     beforeEach(inject(function($filter) {
       utcToLocal = $filter('utcToLocal');
       dateToUTC = $filter('dateToUTC');
+      nextHourString = $filter('nextHourString');
+      lastHourString = $filter('lastHourString');
+      convertToDatetime = $filter('convertToDatetime');
     }));
 
     it('filters should be defined', function () {
@@ -28,19 +32,39 @@
     });
 
     it('should mock native Date', function () {
-      expect(new Date().toISOString()).toEqual('2019-08-02T04:00:00.000Z');
+      expect(new Date().toISOString()).toEqual('2019-08-02T07:14:00.000Z');
     });
 
     it('should convert date to UTC datetime string', function () {
       var date = new Date();
       var result = dateToUTC(date);
-      expect(result).toEqual('2019-08-02 04:00:00');
+      expect(result).toEqual('2019-08-02 07:14:00');
     });
 
     it('should convert UTC date string to local time using the given format', function () {
       var date = new Date('2019-08-02T04:00:00.000Z'); // Note: 4:00 UTC time
       var localTime = utcToLocal(date, 'medium');
       expect(localTime).toEqual('Aug 2, 2019 12:00:00 AM');
+    });
+
+    it('should return nextHourString', function () {
+      var date = new Date();
+      var nextHour = nextHourString(date);
+      expect(nextHour).toEqual('4:00:00 AM EDT');
+    });
+
+    it('should return lastHourString', function () {
+      var date = new Date();
+      var lastHour = lastHourString(date);
+      expect(lastHour).toEqual('3:00:00 AM EDT');
+    });
+
+    it('should merge a date and time into a Datetime string', function () {
+      var date = new Date();
+      var dateString = date.toDateString();
+      var timeString = nextHourString(date);
+      var datetime = convertToDatetime(dateString, timeString);
+      expect(datetime).toEqual('2019-08-02 08:00:00');
     });
   });
 }());


### PR DESCRIPTION
### Changed

- The default offer start and end times to be at the closest hour in the past instead of the next closest hour (#20).

Fixes #20 