### PR TITLE
Disable editing Ironic node properties when creating an offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The default offer start and end times to be at the closest hour in the past instead of the next closest hour (#20).
+- "Create offer" modal now prohibits users from editing unused Ironic node properties (#17).
 
 ### Fixed
 

--- a/flocx_ui/static/dashboard/project/flocx/create-offer/create-offer.html
+++ b/flocx_ui/static/dashboard/project/flocx/create-offer/create-offer.html
@@ -89,18 +89,14 @@
       </div>
       <p class="help-block">Start and end time should be whole hours.</p>
     </div>
-    <div class="form-group">
+    <div class="form-group" style="margin-top: 8px;">
       <label class="col-sm-2 control-label" for="offer-server-config">Properties</label>
       <div class="col-sm-9">
-        <textarea
-          class="form-control"
+        <pre
+          class="pre-scrollable"
           id="offer-server-config"
-          cols="30"
-          rows="10"
-          ng-model="ctrl.config"
-          required
-        >
-        </textarea>
+        >{$ ctrl.config $}
+        </pre>
       </div>
     </div>
     <div class="form-group">


### PR DESCRIPTION
### Changed

- "Create offer" modal now prohibits users from editing unused Ironic node properties (#17).

Fixes #17